### PR TITLE
fix: include nested section index pages in search index

### DIFF
--- a/assets/js/modules/flexsearch/flexsearch.index.js
+++ b/assets/js/modules/flexsearch/flexsearch.index.js
@@ -41,7 +41,7 @@ Source:
 function initIndex() {
   // https://discourse.gohugo.io/t/range-length-or-last-element/3803/2
   // Note: pages without a title (such as browserconfig.xml) are excluded
-  {{ $sections := where site.Sections "Title" "!=" "" }}
+  {{ $sections := where (where site.Pages "Kind" "section") "Title" "!=" "" }}
   {{ $list := where site.RegularPages "Title" "!=" "" | append $sections }}
   {{ $list = where $list ".Params.searchExclude" "!=" true }}
   {{ $len := (len $list) -}}

--- a/exampleSite/content/parent-section/_index.md
+++ b/exampleSite/content/parent-section/_index.md
@@ -1,0 +1,7 @@
+---
+title: Parent section
+description: Top-level section index page
+date: 2026-05-21
+---
+
+This is a top-level section index page (`_index.md` at depth 1).

--- a/exampleSite/content/parent-section/nested-section/_index.md
+++ b/exampleSite/content/parent-section/nested-section/_index.md
@@ -1,0 +1,7 @@
+---
+title: Nested section
+description: Nested section index page
+date: 2026-05-21
+---
+
+This is a nested section index page (`_index.md` at depth 2).


### PR DESCRIPTION
## Summary
- `site.Sections` only enumerates top-level sections, so nested `_index.md` pages (e.g. `/data-science/data-visualization/`) were silently excluded from the FlexSearch index even though top-level section pages are indexed.
- Replaces `site.Sections` with `where site.Pages "Kind" "section"` so section pages at any depth are picked up; the `Title != ""` and `searchExclude` filters are preserved.
- Completes the intent of 58dcea5 (*feat: include section index pages in search index*), whose example paths (`/pricing/`, `/data-catalog/`) happened to be flat and masked the gap.

Reported in gethinode/hinode#1836 (discussioncomment-16995347).

## Test plan
- [x] Reproduced locally by adding `content/data-science/_index.md` and `content/data-science/data-visualization/_index.md` to `exampleSite/`; before the fix only the top-level entry appeared in the built `main.bundle.js`.
- [x] After the fix, both `data-science/` and `data-science/data-visualization/` hrefs and their unique content markers appear in the bundle.
- [x] `npm test` (build) passes via the pre-commit hook.
- [ ] Verify `searchExclude: true` still hides nested section pages.
- [ ] Smoke-test a multilingual site to confirm nested sections are indexed per language when `localize` is enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)