### PR TITLE
feat!: adopt mod-utils v6 (mod-flexsearch v5)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -15,7 +15,7 @@
     min = "0.146.0"
     max = ""
   [[module.imports]]
-    path = "github.com/gethinode/mod-utils/v5"
+    path = "github.com/gethinode/mod-utils/v6"
   [[module.imports]]
     path = "github.com/nextapps-de/flexsearch"
   [[module.imports.mounts]]

--- a/exampleSite/go.mod
+++ b/exampleSite/go.mod
@@ -3,6 +3,5 @@ module github.com/gethinode/mod-flexsearch-test
 go 1.19
 
 require (
-	github.com/gethinode/mod-utils/v5 v5.13.0 // indirect
-	github.com/nextapps-de/flexsearch v0.0.0-20250907103239-defb38b083f0 // indirect
+	github.com/gethinode/mod-utils/v6 v6.0.1 // indirect
 )

--- a/exampleSite/go.sum
+++ b/exampleSite/go.sum
@@ -1,4 +1,2 @@
-github.com/gethinode/mod-utils/v5 v5.13.0 h1:ztkE1REey94x36UdlZ7yeitpIQid/BcZQh+wtxBTSQ8=
-github.com/gethinode/mod-utils/v5 v5.13.0/go.mod h1:PwQN4oOjA6k/vet11JueJ9asZMgL0DBa3jyS9tPkBWU=
-github.com/nextapps-de/flexsearch v0.0.0-20250907103239-defb38b083f0 h1:55phPhe6fDjfjG0jX4+br3nLORKgjgx8abZUdI0YJRA=
-github.com/nextapps-de/flexsearch v0.0.0-20250907103239-defb38b083f0/go.mod h1:5GdMfPAXzbA2gXBqTjC6l27kioSYzHlqDMh0+wyx7sU=
+github.com/gethinode/mod-utils/v6 v6.0.1 h1:EnmMHjqnI/xyHPXFj1SdRLfVxNunJcKLGVtSAAFTQ8w=
+github.com/gethinode/mod-utils/v6 v6.0.1/go.mod h1:E5tO9w3VKaidJpu1nI8zAKmh0bddFHOIIQnudAaXQTs=

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -9,7 +9,7 @@ title = 'Test site for mod-flexsearch'
   home = ["HTML", "RSS", "searchindex"]
 
 [module]
-  replacements = 'github.com/gethinode/mod-flexsearch/v4 -> ../..'
+  replacements = 'github.com/gethinode/mod-flexsearch/v5 -> ../..'
   [[module.mounts]]
     source = "assets"
     target = "assets"
@@ -23,9 +23,9 @@ title = 'Test site for mod-flexsearch'
     source = "static"
     target = "static"
   [[module.imports]]
-    path = "github.com/gethinode/mod-utils/v5"
+    path = "github.com/gethinode/mod-utils/v6"
   [[module.imports]]
-    path = "github.com/gethinode/mod-flexsearch/v4"
+    path = "github.com/gethinode/mod-flexsearch/v5"
   [[module.imports.mounts]]
     source = "assets"
     target = "assets"

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
-module github.com/gethinode/mod-flexsearch/v4
+module github.com/gethinode/mod-flexsearch/v5
 
 go 1.19
 
 require (
-	github.com/gethinode/mod-utils/v5 v5.23.4 // indirect
+	github.com/gethinode/mod-utils/v6 v6.0.1 // indirect
 	github.com/nextapps-de/flexsearch v0.0.0-20260529083235-f7ed963096a0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/gethinode/mod-utils/v5 v5.23.4 h1:/lcKi1MJ2srGfNhCPtdnTRpQgdh2FNBRUAS7Ysz1W34=
-github.com/gethinode/mod-utils/v5 v5.23.4/go.mod h1:PwQN4oOjA6k/vet11JueJ9asZMgL0DBa3jyS9tPkBWU=
+github.com/gethinode/mod-utils/v6 v6.0.1 h1:EnmMHjqnI/xyHPXFj1SdRLfVxNunJcKLGVtSAAFTQ8w=
+github.com/gethinode/mod-utils/v6 v6.0.1/go.mod h1:E5tO9w3VKaidJpu1nI8zAKmh0bddFHOIIQnudAaXQTs=
 github.com/nextapps-de/flexsearch v0.0.0-20260529083235-f7ed963096a0 h1:QDKcU3q39lFGzdVwM6kgCGnW3ibbMfYIi0Rwl62iJpo=
 github.com/nextapps-de/flexsearch v0.0.0-20260529083235-f7ed963096a0/go.mod h1:5GdMfPAXzbA2gXBqTjC6l27kioSYzHlqDMh0+wyx7sU=


### PR DESCRIPTION
## Summary

- Bumps mod-flexsearch's own Go module path from `/v4` to `/v5` and the
  `mod-utils` requirement from `/v5` to `/v6 v6.0.1` (never v6.0.0, which has a
  known camelKey defect), in `go.mod`, `config.toml`, and
  `exampleSite/go.mod`/`hugo.toml`.
- Part of the mod-utils v6 adoption program (gethinode/mod-utils#334); see the
  [v5-to-v6 migration notes](https://github.com/gethinode/mod-utils#migrating-from-v5-to-v6)
  in the mod-utils README.
- **Argument-handling migration (recipe step 4): no-op for this module.**
  mod-flexsearch has zero `InitArgs.html`/`InitTypes.html` call sites and no
  `data/structures` definitions — it reads `site.Params` directly. The only
  mod-utils partial it calls is `utilities/LogWarn.html` (a deprecated
  site-parameter warning in `GetSearchConfig.html`), whose signature is
  unchanged in v6. No template files were touched.

## Verification

- `hugo mod graph` (run from `exampleSite/`) shows only
  `github.com/gethinode/mod-utils/v6@v6.0.1` — no `mod-utils/v5` anywhere,
  including `_vendor`.
- `pnpm run build` (`hugo --gc --minify -s exampleSite`) exits 0 with zero
  ERROR lines. The only WARN lines are pre-existing, unrelated deprecations
  (`languageCode`, `css.Sass`/libsass) and asset-pipeline "Processing file"
  notices — identical before and after the bump. No new warnings surfaced.
- Own-exampleSite visual regression (own harness, `tests/visual/` from the
  gethinode/hinode program branch): baseline captured from the pristine
  clone before any change, candidate shot after the migration, compared with
  `--include "."` (10/10 sitemap pages). Result: **10 ok, 0 flagged**
  (0.0000% diff ratio on every page).

## Call sites migrated

None — this module has no `InitArgs`/`InitTypes` call sites to migrate.

## Warning triage

No new warnings. Pre-existing WARN lines (Hugo `languageCode`/libsass
deprecations, asset "Processing file" notices) are unrelated to mod-utils and
unchanged before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)