### PR TITLE
fix: pass site as the cached search-index context (render-once D7)

### DIFF
--- a/layouts/_partials/assets/search-input.html
+++ b/layouts/_partials/assets/search-input.html
@@ -10,7 +10,7 @@
 
 <div class="d-flex flex-fill ms-md-3{{ with $class }} {{ . }}{{ end }}">
     <form class="search flex-fill position-relative me-auto">
-        <input class="search-input form-control is-search" type="search" placeholder="{{ T "ui_search" }}" aria-label="{{ T "ui_search" }}" autocomplete="off" name="search-input"{{ if $lazy }} data-search-index="{{ partialCached "utilities/GetSearchIndex.html" page page.Language.Lang }}"{{ end }}>
+        <input class="search-input form-control is-search" type="search" placeholder="{{ T "ui_search" }}" aria-label="{{ T "ui_search" }}" autocomplete="off" name="search-input"{{ if $lazy }} data-search-index="{{ partialCached "utilities/GetSearchIndex.html" site site.Language.Lang }}"{{ end }}>
         <div class="search-suggestions shadow bg-body rounded d-none" data-no-results="{{ T "ui_no_results" }}"></div>
     </form>
 </div>

--- a/layouts/_shortcodes/ModalSearch.html
+++ b/layouts/_shortcodes/ModalSearch.html
@@ -8,7 +8,7 @@
                 <div class="modal-header">
                     <div class="w-100">
                         <form class="search position-relative me-auto">
-                            <input id="search-input-modal" class="search-input form-control is-search" tabindex="1" type="search" placeholder="{{ T "ui_search" }}..." aria-label="{{ T "ui_search" }}" autocomplete="off"{{ if $lazy }} data-search-index="{{ partialCached "utilities/GetSearchIndex.html" page page.Language.Lang }}"{{ end }}>
+                            <input id="search-input-modal" class="search-input form-control is-search" tabindex="1" type="search" placeholder="{{ T "ui_search" }}..." aria-label="{{ T "ui_search" }}" autocomplete="off"{{ if $lazy }} data-search-index="{{ partialCached "utilities/GetSearchIndex.html" site site.Language.Lang }}"{{ end }}>
                         </form>
                     </div>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ T "close" }}"></button>


### PR DESCRIPTION
## Render-once program — slice D7

Both `GetSearchIndex` `partialCached` calls now pass `site` as context (the partial depends only on `site.Home`; language key kept). Byte-neutral, verified additionally with lazyLoad forced on.

Part of the Hinode render-once implementation program (design: gethinode.com `docs/superpowers/specs/2026-07-15-content-render-once-design.md` §2.3/§4.5/§6-D7, Appendix C). Diagnostics-only: replaces global-`page` warning attribution with the intrinsic page where one is in scope; no output bytes change.

**Gate:** exampleSite with all four D7 module branches replaced simultaneously — 0 ERROR, 98/26/24 pages, WARN set identical; candidate vs unpatched-main control: byte-neutral (only the 3 allowlisted RSS files). Independently re-verified by the program driver. Module test suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)