### PR TITLE
feat: build the search index after page renders via templates.Defer (render-once B)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,10 +51,12 @@ The module imports `github.com/nextapps-de/flexsearch` and mounts its bundle to 
 - `layouts/_partials/assets/search-input.html`: Embedded search form HTML structure
 - `layouts/_shortcodes/ModalSearch.html`: Modal search dialog structure
 - `layouts/_partials/assets/search-meta.html`: Recursive helper to extract frontmatter content for indexing
-- `layouts/_partials/utilities/GetSearchDocs.html`: Single source of truth — builds the slice of index documents (consumed by both the eager JS and the lazy JSON output)
-- `layouts/index.searchindex.json`: Layout for the `searchindex` output format — emits the index documents as JSON on the home page (lazy mode)
-- `layouts/_partials/utilities/GetSearchIndex.html`: Returns the URL of the search-index output (lazy mode)
-- `assets/js/modules/flexsearch/flexsearch.index.js`: FlexSearch initialization and search logic
+- `layouts/_partials/utilities/GetSearchDocs.html`: Single source of truth — builds the slice of index documents (accepts an explicit `site` because it runs inside `templates.Defer`)
+- `layouts/_partials/assets/search-index.html`: Publishes the index documents as a per-language JSON asset from a `templates.Defer` block — i.e. after all pages have rendered, keeping the expensive `.Plain` walk off the render critical path. Included by `search-input.html` and `ModalSearch.html`; renders no output
+- `layouts/_partials/utilities/GetSearchIndexPath.html`: Returns the deterministic publish path of the index asset (`js/flexsearch-index.<lang>.json`)
+- `layouts/_partials/utilities/GetSearchIndex.html`: Returns the URL of the index asset (embedded into the runtime bundle at build time)
+- `layouts/index.searchindex.json`: Legacy layout for the deprecated `searchindex` output format — now always emits an empty array; kept so sites that still list the format keep building
+- `assets/js/modules/flexsearch/flexsearch.index.js`: FlexSearch initialization and search logic; fetches the index asset at runtime
 
 **Search index configuration:**
 - The index documents are built by `GetSearchDocs.html` from Hugo's page content
@@ -64,13 +66,17 @@ The module imports `github.com/nextapps-de/flexsearch` and mounts its bundle to 
 - Can use absolute URLs via `flexsearch.canonifyURLs` parameter
 - Pages can be excluded with `searchExclude: true` in frontmatter
 - Supports optional `indexTitle` parameter to override title in search results
-- **Eager mode (default):** `flexsearch.index.js` emits one flat `index.add(...)`
-  statement per page into the core bundle (a chained `.add()` expression
-  overflows the minifier's expression-nesting limit on large sites)
-- **Lazy mode (`flexsearch.lazyLoad`):** the index is emitted as a separate
-  per-language JSON file via the `searchindex` output format and fetched on
-  the first search interaction (a normal page render, so page content can be
-  aggregated safely — unlike a detached resource template)
+- The index payload is never bundled into the page scripts: it is published as
+  a per-language JSON asset (`js/flexsearch-index.<lang>.json`) from a
+  `templates.Defer` block, so the `.Plain` walk over all pages runs after the
+  site has rendered (reusing Hugo's cached content) instead of serializing the
+  render pipeline inside the script-bundle mutex
+- **Eager fetch (default):** the runtime fetches the JSON as soon as the core
+  bundle executes on a page with a search input
+- **Lazy fetch (`flexsearch.lazyLoad`):** the fetch is postponed until the
+  first search interaction (focus/click on the input, or opening the modal)
+- Requires CSP `connect-src 'self'` in both modes; the module declares it in
+  its `csp` block
 
 **Search behavior:**
 - Shows up to 5 results across title, description, and content fields
@@ -93,7 +99,7 @@ Module configuration in `config.toml` under `params.modules.flexsearch`:
 - `frontmatter` (default: false): Include frontmatter content in search index
 - `filter` (default: "params"): Restrict frontmatter scanning to specific key
 - `summaryOnly` (default: false): Index page summaries instead of full content
-- `lazyLoad` (default: false): Emit the index as a separate JSON file fetched on first search interaction, instead of bundling it into every page
+- `lazyLoad` (default: false): Postpone fetching the search-index JSON until the first search interaction, instead of fetching it as soon as the page's scripts run
 - `localize` (default: true): Enable language-specific search
 
 Navigation configuration under `params.navigation.search`:

--- a/README.md
+++ b/README.md
@@ -48,13 +48,19 @@ This module supports the following parameters (see the section `params.modules` 
 | `flexsearch.frontmatter`  | false    | If set, includes front matter in the page content. The search index function adds all parameters with the name `content`, `heading`, `title`, `preheading` recursively. |
 | `flexsearch.filter`       | "params" | Restricts the scanned frontmatter variables to the named filter. By default, all front matter variables are scanned. Only applicable when `flexsearch.frontmatter` is set. |
 | `flexsearch.summaryOnly`  | false    | If set, indexes each page's summary instead of its full content. Reduces the size of the generated search index considerably on large sites, at the cost of matching only summary text. |
-| `flexsearch.lazyLoad`     | false    | If set, the search index is emitted as a separate per-language JSON file and fetched on the visitor's first search interaction, instead of being bundled into the core script loaded on every page. See the note below on Content Security Policy. |
+| `flexsearch.lazyLoad`     | false    | If set, postpones fetching the search index until the visitor's first search interaction. By default the index is fetched as soon as the page's scripts run. See the note below on how the index is published. |
 
 > [!NOTE]
-> With `flexsearch.lazyLoad` enabled the search index is fetched at runtime. A
-> site that sets a strict Content Security Policy must allow `connect-src 'self'`.
-> The module declares this directive in its `csp` block, so sites using the
-> Hinode CSP module pick it up automatically.
+> The search index is published as a separate per-language JSON asset
+> (`js/flexsearch-index.<lang>.json`) and fetched at runtime; it is not bundled
+> into the core script loaded on every page. The asset is generated after all
+> pages have rendered (via `templates.Defer`), which keeps the index build off
+> the render critical path and speeds up site builds. A site that sets a strict
+> Content Security Policy must allow `connect-src 'self'`. The module declares
+> this directive in its `csp` block, so sites using the Hinode CSP module pick
+> it up automatically. Sites that override the `search-input.html` partial or
+> the `ModalSearch` shortcode must keep the include of
+> `assets/search-index.html`, which publishes the index asset.
 
 In addition, the module recognizes the following site parameters (see the section `params.navigation` in `config.toml`):.
 

--- a/assets/js/modules/flexsearch/flexsearch.index.js
+++ b/assets/js/modules/flexsearch/flexsearch.index.js
@@ -34,12 +34,14 @@ var index = new FlexSearch.Document({
   }
 });
 
-{{ if $lazy -}}
 /*
-  Lazy mode: the index data is fetched from a standalone JSON resource the
-  first time the user interacts with search, instead of being bundled into
-  every page. The data URL is read from the search input's data-search-index
-  attribute (set by the search-input / ModalSearch layouts).
+  The index data is fetched from a standalone per-language JSON asset that is
+  published by the assets/search-index.html partial via templates.Defer, i.e.
+  after all pages have rendered. Keeping the payload out of the script bundle
+  keeps the expensive index build off the render critical path. By default the
+  fetch starts as soon as this script executes; with lazyLoad enabled it is
+  postponed until the first search interaction. A data-search-index attribute
+  on the search input (legacy lazy-mode layouts) overrides the built-in URL.
 */
 let indexStatus = 'idle'; // idle | loading | ready | error
 
@@ -47,12 +49,7 @@ function loadIndex() {
   if (indexStatus !== 'idle') return;
   indexStatus = 'loading';
 
-  const url = search.dataset.searchIndex;
-  if (!url) {
-    indexStatus = 'error';
-    console.error('flexsearch: missing data-search-index URL on the search input');
-    return;
-  }
+  const url = search.dataset.searchIndex || {{ partial "utilities/GetSearchIndex.html" . | jsonify }};
 
   fetch(url)
     .then((response) => {
@@ -71,19 +68,6 @@ function loadIndex() {
       console.error('flexsearch: failed to load search index', err);
     });
 }
-{{- else -}}
-/*
-Source:
-  - https://github.com/nextapps-de/flexsearch#index-documents-field-search
-  - https://raw.githack.com/nextapps-de/flexsearch/master/demo/autocomplete.html
-*/
-function initIndex() {
-  {{- range $doc := partial "utilities/GetSearchDocs.html" . }}
-  index.add({{ $doc | jsonify }});
-  {{- end }}
-  search.addEventListener('input', showResults, true);
-}
-{{- end }}
 
 function hideSuggestions(e) {
   var isClickInsideElement = suggestions.contains(e.target);
@@ -214,7 +198,7 @@ if (search !== null && suggestions !== null) {
   search.addEventListener('focus', loadIndex, { once: true });
   search.addEventListener('click', loadIndex, { once: true });
   {{- else -}}
-  initIndex();
+  loadIndex();
   {{- end }}
 }
 

--- a/exampleSite/content/ninth.md
+++ b/exampleSite/content/ninth.md
@@ -1,0 +1,20 @@
+---
+title: Ninth page
+description: Demos the search input inside page content, so the search index must not leak a deferred placeholder token.
+# The explicit summary is load-bearing: without it, RSS embeds the derived
+# .Summary — which carries the raw templates.Defer placeholder emitted by the
+# search-demo shortcode — and Hugo panics substituting a deferred placeholder
+# inside RSS output ("deferred execution with id ... not found"). The page's
+# .Plain still carries the token, which is what the index fixture needs.
+summary: Demos the search input inside page content.
+---
+
+This page embeds the search UI in its own content. The included search-index
+publisher runs inside `templates.Defer`, which leaves a raw placeholder token
+in this page's in-memory plain text; `GetSearchDocs.html` must strip it before
+publishing the index.
+
+{{< search-demo >}}
+
+Text after the demo, so the placeholder sits mid-content rather than at a
+trimmed edge.

--- a/exampleSite/layouts/shortcodes/search-demo.html
+++ b/exampleSite/layouts/shortcodes/search-demo.html
@@ -1,0 +1,10 @@
+{{- /*
+    Renders the search input inside page content, the way a theme demos a
+    search-enabled component (e.g. Hinode's navbar shortcode with search
+    enabled). This embeds the deferred search-index publisher in the page's
+    .Content, leaving a raw templates.Defer placeholder in the in-memory
+    .Plain that GetSearchDocs.html reads inside the deferred block — the
+    fixture for the placeholder-stripping regression check in
+    scripts/check-search-index.mjs.
+*/ -}}
+{{ partial "assets/search-input.html" (dict "class" "border") }}

--- a/layouts/_partials/assets/search-index.html
+++ b/layouts/_partials/assets/search-index.html
@@ -1,0 +1,25 @@
+{{- /*
+    Publishes the per-language search index as a standalone JSON asset. The
+    heavy lifting (GetSearchDocs.html touches `.Plain` of every page) runs
+    inside templates.Defer, i.e. AFTER all pages have rendered: `.Plain` then
+    reuses Hugo's cached content instead of forcing serial page renders inside
+    the script-bundle mutex, which used to stall the whole render pipeline.
+
+    The block renders no output — the deferred placeholder is replaced with an
+    empty string — so including this partial leaves the page HTML untouched.
+    It is keyed per language: no matter how many pages include it, the index
+    is built exactly once per language.
+
+    Include it from every template that renders a search UI (search-input.html
+    and ModalSearch.html do); without at least one inclusion per language the
+    index asset is not published and the runtime fetch would 404.
+*/ -}}
+{{- with (templates.Defer (dict
+    "key" (printf "flexsearch-index-%s" site.Language.Lang)
+    "data" (dict "site" site)
+)) -}}
+    {{- $site := .site -}}
+    {{- $docs := partial "utilities/GetSearchDocs.html" (dict "site" $site) -}}
+    {{- $index := resources.FromString (partial "utilities/GetSearchIndexPath.html" $site) ($docs | jsonify) -}}
+    {{- $noop := $index.RelPermalink -}}
+{{- end -}}

--- a/layouts/_partials/assets/search-input.html
+++ b/layouts/_partials/assets/search-input.html
@@ -6,11 +6,11 @@
 -->
 
 {{- $class := .class -}}
-{{- $lazy := site.Params.modules.flexsearch.lazyLoad | default false -}}
 
 <div class="d-flex flex-fill ms-md-3{{ with $class }} {{ . }}{{ end }}">
     <form class="search flex-fill position-relative me-auto">
-        <input class="search-input form-control is-search" type="search" placeholder="{{ T "ui_search" }}" aria-label="{{ T "ui_search" }}" autocomplete="off" name="search-input"{{ if $lazy }} data-search-index="{{ partialCached "utilities/GetSearchIndex.html" site site.Language.Lang }}"{{ end }}>
+        <input class="search-input form-control is-search" type="search" placeholder="{{ T "ui_search" }}" aria-label="{{ T "ui_search" }}" autocomplete="off" name="search-input">
         <div class="search-suggestions shadow bg-body rounded d-none" data-no-results="{{ T "ui_no_results" }}"></div>
     </form>
 </div>
+{{- partial "assets/search-index.html" . -}}

--- a/layouts/_partials/utilities/GetSearchDocs.html
+++ b/layouts/_partials/utilities/GetSearchDocs.html
@@ -15,7 +15,16 @@
     templates.Defer, where the `site` global does not reliably reflect the
     language that registered the deferred block. A bare (non-dict) context
     falls back to the `site` global for backward compatibility.
+
+    Placeholder hygiene: a page that demos a search UI in its own content (e.g.
+    a navbar shortcode with search enabled) embeds the deferred search-index
+    publisher inside its .Content, which leaves a raw templates.Defer
+    placeholder token (`__hdeferred/<id>__d=`) in the in-memory .Plain/.Summary
+    read by this partial — Hugo only substitutes placeholders in published page
+    output, not in content strings captured inside a deferred block. Strip the
+    token (and one trailing whitespace) so the published index stays clean.
 */ -}}
+{{- $deferToken := `__hdeferred/\S+?__d=\s?` -}}
 {{- $site := site -}}
 {{- if reflect.IsMap . }}{{ with .site }}{{ $site = . }}{{ end }}{{ end -}}
 {{- $sections := where (where $site.Pages "Kind" "section") "Title" "!=" "" -}}
@@ -48,6 +57,8 @@
         in scripts/check-search-index.mjs flags as uncollapsed whitespace.
     */ -}}
     {{- $description = $description | plainify | htmlUnescape -}}
+    {{- /* strip defer placeholders before the truncate below can cut one in half */ -}}
+    {{- $description = replaceRE $deferToken "" $description -}}
     {{- $description = trim (replaceRE `[\s\p{Zs}\p{Zl}\p{Zp}\x{000B}\x{0085}\x{FEFF}]+` " " $description) " " | truncate 100 "..." | htmlUnescape -}}
     {{- $content := "" -}}
     {{- if $site.Params.modules.flexsearch.summaryOnly -}}
@@ -55,6 +66,7 @@
     {{- else -}}
         {{- $content = replaceRE "[{}]" "" .Plain -}}
     {{- end -}}
+    {{- $content = replaceRE $deferToken "" $content -}}
     {{- if $site.Params.modules.flexsearch.frontmatter -}}
         {{- $key := $site.Params.modules.flexsearch.filter | default "params" -}}
         {{- $val := slice -}}

--- a/layouts/_partials/utilities/GetSearchDocs.html
+++ b/layouts/_partials/utilities/GetSearchDocs.html
@@ -2,24 +2,32 @@
     Builds the list of documents for the FlexSearch index. Returns a slice of
     dicts with the keys: id, href, title, description, content.
 
-    This is the single source of truth for index documents — it is consumed
-    both by the eager path (flexsearch.index.js, inline index.add() calls) and
-    the lazy path (flexsearch-index.json, fetched on demand).
+    This is the single source of truth for index documents — it is consumed by
+    assets/search-index.html, which publishes them as a per-language JSON asset
+    from a deferred template (after all pages have rendered).
 
     Honors the params.modules.flexsearch settings: canonifyURLs, summaryOnly,
     frontmatter, filter. Pages without a title and pages with searchExclude
     are omitted.
+
+    Context: a dict with the key "site" holding the (language) Site to index.
+    Passing the site explicitly is required because this partial runs inside
+    templates.Defer, where the `site` global does not reliably reflect the
+    language that registered the deferred block. A bare (non-dict) context
+    falls back to the `site` global for backward compatibility.
 */ -}}
-{{- $sections := where (where site.Pages "Kind" "section") "Title" "!=" "" -}}
-{{- $list := where site.RegularPages "Title" "!=" "" | append $sections -}}
+{{- $site := site -}}
+{{- if reflect.IsMap . }}{{ with .site }}{{ $site = . }}{{ end }}{{ end -}}
+{{- $sections := where (where $site.Pages "Kind" "section") "Title" "!=" "" -}}
+{{- $list := where $site.RegularPages "Title" "!=" "" | append $sections -}}
 {{- $list = where $list ".Params.searchExclude" "!=" true -}}
 {{- $docs := slice -}}
 {{- range $index, $element := sort $list "Title" "asc" -}}
     {{- $url := .RelPermalink -}}
-    {{- if site.Params.modules.flexsearch.canonifyURLs }}{{ $url = .Permalink }}{{ end -}}
+    {{- if $site.Params.modules.flexsearch.canonifyURLs }}{{ $url = .Permalink }}{{ end -}}
     {{- $title := or .Params.indexTitle .LinkTitle .Title -}}
     {{- if gt (strings.RuneCount $title) 33 }}{{ $title = print (substr $title 0 30) "..." }}{{ end -}}
-    {{- if and site.Params.main.titleCase (not $element.Params.exact) }}{{ $title = title $title }}{{ end -}}
+    {{- if and $site.Params.main.titleCase (not $element.Params.exact) }}{{ $title = title $title }}{{ end -}}
     {{- $description := "" -}}
     {{- with .Description }}{{ $description = . }}{{ else }}{{ $description = $element.Summary }}{{ end -}}
     {{/*
@@ -42,13 +50,13 @@
     {{- $description = $description | plainify | htmlUnescape -}}
     {{- $description = trim (replaceRE `[\s\p{Zs}\p{Zl}\p{Zp}\x{000B}\x{0085}\x{FEFF}]+` " " $description) " " | truncate 100 "..." | htmlUnescape -}}
     {{- $content := "" -}}
-    {{- if site.Params.modules.flexsearch.summaryOnly -}}
+    {{- if $site.Params.modules.flexsearch.summaryOnly -}}
         {{- $content = replaceRE "[{}]" "" (.Summary | plainify) -}}
     {{- else -}}
         {{- $content = replaceRE "[{}]" "" .Plain -}}
     {{- end -}}
-    {{- if site.Params.modules.flexsearch.frontmatter -}}
-        {{- $key := site.Params.modules.flexsearch.filter | default "params" -}}
+    {{- if $site.Params.modules.flexsearch.frontmatter -}}
+        {{- $key := $site.Params.modules.flexsearch.filter | default "params" -}}
         {{- $val := slice -}}
         {{- if ne $key "params" }}{{ $val = index .Params $key }}{{ else }}{{ $val = .Params }}{{ end -}}
         {{- $content = printf "%s %s" (partial "assets/search-meta.html" (dict "key" $key "val" $val)) $content -}}

--- a/layouts/_partials/utilities/GetSearchIndex.html
+++ b/layouts/_partials/utilities/GetSearchIndex.html
@@ -1,10 +1,6 @@
 {{- /*
-    Returns the URL of the per-language search index — the `searchindex` output
-    format rendered on the home page. Consumed by the search input layouts to
-    populate the data-search-index attribute the lazy runtime fetches.
+    Returns the URL of the per-language search index asset published by
+    assets/search-index.html. Consumed by the flexsearch runtime bundle to
+    know where to fetch the index data.
 */ -}}
-{{- $url := "" -}}
-{{- with site.Home.OutputFormats.Get "searchindex" -}}
-    {{- $url = .RelPermalink -}}
-{{- end -}}
-{{- return $url -}}
+{{- return relURL (partial "utilities/GetSearchIndexPath.html" site) -}}

--- a/layouts/_partials/utilities/GetSearchIndexPath.html
+++ b/layouts/_partials/utilities/GetSearchIndexPath.html
@@ -1,0 +1,11 @@
+{{- /*
+    Returns the publish path of the per-language search index asset, e.g.
+    "js/flexsearch-index.en.json". The path is deterministic on purpose: the
+    producer (assets/search-index.html, which publishes the resource from a
+    deferred template after all pages have rendered) and the consumers (the
+    flexsearch runtime bundle and utilities/GetSearchIndex.html) must agree on
+    the location before the resource exists.
+
+    Context: the (language) Site whose index is addressed.
+*/ -}}
+{{- return printf "js/flexsearch-index.%s.json" .Language.Lang -}}

--- a/layouts/_shortcodes/ModalSearch.html
+++ b/layouts/_shortcodes/ModalSearch.html
@@ -1,5 +1,4 @@
 {{- $search := partial "utilities/GetSearchConfig.html" (dict "search" true) -}}
-{{- $lazy := site.Params.modules.flexsearch.lazyLoad | default false -}}
 
 {{- if $search.modal }}
     <div id="search-modal" class="modal fade search-modal" tabindex="-1" aria-labelledby="searchModalLabel" aria-hidden="true" aria-modal="true">
@@ -8,7 +7,7 @@
                 <div class="modal-header">
                     <div class="w-100">
                         <form class="search position-relative me-auto">
-                            <input id="search-input-modal" class="search-input form-control is-search" tabindex="1" type="search" placeholder="{{ T "ui_search" }}..." aria-label="{{ T "ui_search" }}" autocomplete="off"{{ if $lazy }} data-search-index="{{ partialCached "utilities/GetSearchIndex.html" site site.Language.Lang }}"{{ end }}>
+                            <input id="search-input-modal" class="search-input form-control is-search" tabindex="1" type="search" placeholder="{{ T "ui_search" }}..." aria-label="{{ T "ui_search" }}" autocomplete="off">
                         </form>
                     </div>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ T "close" }}"></button>
@@ -18,5 +17,6 @@
                 </div>
             </div>
         </div>
-    </div> 
+    </div>
+    {{- partial "assets/search-index.html" . -}}
 {{ end -}}

--- a/layouts/index.searchindex.json
+++ b/layouts/index.searchindex.json
@@ -1,15 +1,9 @@
 {{- /*
-    Renders the FlexSearch index documents as a JSON array. Emitted as the
-    `searchindex` output format on the home page so the data is built during a
-    normal page render (where the page context is available) rather than from a
-    detached resource template.
-
-    The lazy runtime fetches this file on the first search interaction. When
-    lazyLoad is disabled the file is still emitted, but empty — the index is
-    bundled into the core script instead.
+    Layout for the legacy `searchindex` output format. Deprecated: the search
+    index is now always published as a per-language asset (see
+    utilities/GetSearchIndexPath.html) by assets/search-index.html, from a
+    deferred template that runs after all pages have rendered. This layout
+    remains so sites that still list the `searchindex` output format for the
+    home page keep building; it emits an empty array.
 */ -}}
-{{- if site.Params.modules.flexsearch.lazyLoad -}}
-{{- (partial "utilities/GetSearchDocs.html" .) | jsonify -}}
-{{- else -}}
 []
-{{- end -}}

--- a/scripts/check-search-index.mjs
+++ b/scripts/check-search-index.mjs
@@ -5,7 +5,7 @@
 */
 import { readFile } from 'node:fs/promises'
 
-const INDEX = 'exampleSite/public/flexsearch-index.json'
+const INDEX = 'exampleSite/public/js/flexsearch-index.en.json'
 const MAX_DESCRIPTION = 100
 const ELLIPSIS = '...'
 const MAX_LENGTH = MAX_DESCRIPTION + ELLIPSIS.length
@@ -19,7 +19,7 @@ try {
   docs = JSON.parse(await readFile(INDEX, 'utf8'))
 } catch (err) {
   console.error(`unable to read ${INDEX}: ${err.message}`)
-  console.error('run `pnpm build` first, and confirm the exampleSite emits the searchindex output format')
+  console.error('run `pnpm build` first, and confirm the exampleSite publishes the search index asset')
   process.exit(1)
 }
 

--- a/scripts/check-search-index.mjs
+++ b/scripts/check-search-index.mjs
@@ -31,6 +31,17 @@ for (const doc of docs) {
   const description = doc.description ?? ''
   const where = `"${doc.title}"`
 
+  // A page that demos the search UI inside its own content embeds the deferred
+  // search-index publisher in .Content, which leaves a raw templates.Defer
+  // placeholder (`__hdeferred/<id>__d=`) in the .Plain that GetSearchDocs.html
+  // reads inside the deferred block. GetSearchDocs.html strips it; a leak here
+  // means that strip regressed. Checked on every field of every doc.
+  for (const [field, value] of Object.entries(doc)) {
+    if (typeof value === 'string' && value.includes('__hdeferred')) {
+      fail(`${where}: ${field} leaks a templates.Defer placeholder — ${excerpt(value)}`)
+    }
+  }
+
   // Hugo caps by rune, not UTF-16 code unit; count runes here too, otherwise a
   // correctly-capped description containing astral characters (e.g. emoji) would
   // false-fail against a .length that runs ahead of the true rune count.
@@ -120,6 +131,16 @@ if (!eighth) {
   if (eighthRuneLength < MIN_CJK_RUNE_LENGTH) {
     fail(`fixture "Eighth page" description is only ${eighthRuneLength} runes, under the ${MIN_CJK_RUNE_LENGTH}-rune floor — truncation likely cut by byte, not by rune — ${excerpt(eighth.description)}`)
   }
+}
+
+/*
+  "Ninth page" embeds the search UI in its own content via the search-demo
+  shortcode — the only fixture whose .Plain carries a deferred placeholder
+  token, so the leak assertion above would pass vacuously without it.
+*/
+const ninth = docs.find((doc) => doc.title === 'Ninth page')
+if (!ninth) {
+  fail('fixture page "Ninth page" is missing from the index')
 }
 
 if (failures.length > 0) {


### PR DESCRIPTION
## Render-once program — chunk B (HELD: merge after hinode#2042's runbook completes)

The parked `perf/defer-index-build` branch, rebased onto main (v5.0.3-era) and completed.
The index publishes per language from a `templates.Defer` block after all page renders;
the runtime always fetches (`lazyLoad` now only controls fetch timing).

### Why now
The original park (2026-07-15) cited an absent wall win and a gate polluted by build
nondeterminism. Both causes are resolved by the render-once flip (gethinode/hinode#2042):
- **Measured on the flip base (M1 Pro, medians of 3 warm-stable runs): wall 10.92 → 7.32 s
  (−33%) at +1.6 s user CPU** — the serial index build dominated the post-flip critical path.
- Gate on the flip base: candidate double builds **fully byte-identical**; search index EN/FR/NL
  byte- and order-identical to stock; every candidate-vs-stock diff is the expected search-asset
  class or a correction of a stock defect (4 pages' broken sprite refs).

### Placeholder-token fix (second commit)
A page demoing `search="true"` in content leaked an unsubstituted `__hdeferred/…__d=` token
into the published index (tokens substitute in HTML but not in `resources.FromString` assets).
Fixed by stripping the token in `GetSearchDocs.html` (before truncation); regression fixture +
check-script assertion included, verified both ways.

### ⚠️ Hazard documented for reviewers
Empirical Defer-token matrix: HTML → substituted; `resources.FromString` asset → raw leak (now
stripped); **RSS/XML → Hugo panics** (`deferred execution with id … not found`). hinode's own
rss.xml is safe (frontmatter descriptions), but a downstream site embedding a derived
`.Summary` of a search-demo page in a feed would crash — suggest a docs note and/or an
upstream Hugo issue.

### Sequencing
Gate-clean ONLY on the flip base — on current main the pre-flip UID race still pollutes the
candidate. **Merge order: hinode#2042 runbook first, then this.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)