### PR TITLE
fix: publish the search index on Hugo < 0.164 (avoid the PostProcess/Defer clash)

### DIFF
--- a/layouts/_partials/assets/search-index.html
+++ b/layouts/_partials/assets/search-index.html
@@ -13,13 +13,34 @@
     Include it from every template that renders a search UI (search-input.html
     and ModalSearch.html do); without at least one inclusion per language the
     index asset is not published and the runtime fetch would 404.
+
+    Hugo version gate: on Hugo < 0.164 a page that uses `resources.PostProcess`
+    silently prevents that page's `templates.Defer` blocks from executing — and
+    the theme's production stylesheet always uses `resources.PostProcess` (it is
+    how `css.PostCSS` is deferred so PurgeCSS reads a complete hugo_stats.json).
+    The deferred index would then never publish and its raw placeholder token
+    would leak into the rendered page. So on Hugo < 0.164 publish the index
+    EAGERLY instead: correct, at the cost of the serial-render stall that
+    templates.Defer was introduced to avoid. Guard the eager path to run once
+    per language via site.Store. Hugo >= 0.164 keeps the deferred path.
+    (hugo.Version.Compare returns > 0 when the running version is older.)
 */ -}}
-{{- with (templates.Defer (dict
-    "key" (printf "flexsearch-index-%s" site.Language.Lang)
-    "data" (dict "site" site)
-)) -}}
-    {{- $site := .site -}}
-    {{- $docs := partial "utilities/GetSearchDocs.html" (dict "site" $site) -}}
-    {{- $index := resources.FromString (partial "utilities/GetSearchIndexPath.html" $site) ($docs | jsonify) -}}
-    {{- $noop := $index.RelPermalink -}}
+{{- if le (hugo.Version.Compare "0.164.0") 0 -}}
+    {{- with (templates.Defer (dict
+        "key" (printf "flexsearch-index-%s" site.Language.Lang)
+        "data" (dict "site" site)
+    )) -}}
+        {{- $site := .site -}}
+        {{- $docs := partial "utilities/GetSearchDocs.html" (dict "site" $site) -}}
+        {{- $index := resources.FromString (partial "utilities/GetSearchIndexPath.html" $site) ($docs | jsonify) -}}
+        {{- $noop := $index.RelPermalink -}}
+    {{- end -}}
+{{- else -}}
+    {{- $guard := printf "flexsearch-index-eager-%s" site.Language.Lang -}}
+    {{- if not (site.Store.Get $guard) -}}
+        {{- site.Store.Set $guard true -}}
+        {{- $docs := partial "utilities/GetSearchDocs.html" (dict "site" site) -}}
+        {{- $index := resources.FromString (partial "utilities/GetSearchIndexPath.html" site) ($docs | jsonify) -}}
+        {{- $noop := $index.RelPermalink -}}
+    {{- end -}}
 {{- end -}}


### PR DESCRIPTION
## The bug

On **Hugo < 0.164**, a page that uses `resources.PostProcess` silently prevents that page's
`templates.Defer` blocks from executing (Hugo 0.164 fixed this coexistence). The Hinode theme's
**production stylesheet always** pipes CSS through `… | fingerprint | resources.PostProcess` — and
that is load-bearing: it is how `css.PostCSS` is deferred to post-build so PurgeCSS reads a
complete `hugo_stats.json`. This partial's search index uses `templates.Defer`. On Hugo
0.146–0.163 the two collide: the deferred index **never publishes** and its raw
`__hdeferred/…__d=` placeholder **leaks into the rendered navbar search box**.

It's masked in this repo's / Hinode's own CI because those build with Hugo 0.164.

**Minimal repro (no Hinode, no flexsearch):** a `<head>` doing
`resources.FromString | minify | fingerprint | resources.PostProcess` plus a `templates.Defer`
block in the body → on 0.161 the deferred block never runs and its token leaks; on 0.164 it's clean.

## The fix

Version-gate the publisher in `assets/search-index.html`:
- **Hugo ≥ 0.164:** unchanged — `templates.Defer` (no serial render).
- **Hugo < 0.164:** publish the index **eagerly** instead, guarded to run once per language via
  `site.Store`. Correct output; the cost is the serial-render stall that `templates.Defer` was
  introduced to avoid — paid only on old Hugo.

`hugo.Version.Compare "0.164.0"` is used for a semantic (not string) version test.

## Evidence (Hinode exampleSite, `hugo --gc --minify`)

| Hugo | search index | `__hdeferred` leak |
| --- | --- | --- |
| 0.146.7 | published | **0** |
| 0.147.6 | published | **0** |
| 0.161.1 (eager) | published | **0** |
| 0.164.0 (deferred) | published | **0** |

- **0.161 (eager) vs 0.164 (deferred): index byte-identical (550,561 B)** — the eager path produces
  exactly the deferred output.
- The small 0.147.6-vs-0.164 index delta is cross-Hugo-version content rendering
  (`.Plain`/`.Summary`), not the fix.

Held for review. (Found while adopting the Hinode v3.6.0 styles pipeline in the starter template,
whose deploy preview builds with Hugo 0.158/0.161 and surfaced the leak.)