### PR TITLE
feat: declare flexsearch script global and worker_threads external for Hinode's module reader

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -52,5 +52,11 @@
     summaryOnly = false
     lazyLoad = false
     localize = true
+    # flexsearch's UMD build doesn't self-register window.FlexSearch when bundled
+    # by esbuild, and its Node-guarded require('worker_threads') must be left as
+    # an esbuild external (it never executes in browsers).
+    externals = ["worker_threads"]
   [params.modules.flexsearch.csp]
     connect-src = ["'self'"]
+  [params.modules.flexsearch.globals]
+    "js/modules/flexsearch/flexsearch.bundle.min.js" = "FlexSearch"


### PR DESCRIPTION
Hinode's scripts pipeline now reads each module's own modules.<name>.globals
and modules.<name>.externals instead of hardcoding them. Declare
window.FlexSearch and the worker_threads esbuild external here so flexsearch
owns its own declaration (mirrors mod-mermaid's [modules.mermaid] block).
