### PR TITLE
feat: declare script globals as an array of {path, name} tables

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -58,5 +58,6 @@
     externals = ["worker_threads"]
   [params.modules.flexsearch.csp]
     connect-src = ["'self'"]
-  [params.modules.flexsearch.globals]
-    "js/modules/flexsearch/flexsearch.bundle.min.js" = "FlexSearch"
+  [[params.modules.flexsearch.globals]]
+    path = "js/modules/flexsearch/flexsearch.bundle.min.js"
+    name = "FlexSearch"


### PR DESCRIPTION
## Summary

Migrates the declared script-globals from a path-keyed **map** to the **array-of-tables** form `[[...globals]]` with `path` + `name`, matching the case-preserving globals convention (Hugo lowercases TOML config keys, so path-keyed maps break for capitalized bundle filenames). This module's bundle name is lowercase so it was never broken, but the convention is moving uniformly across the ecosystem. Same window registration, new schema.

The `externals` list is unchanged; only `globals` migrates.

## Requires

Hinode with the array-of-tables globals reader (v3.10.0+, from hinode#2064). That reader also still accepts the legacy map form, so older hinode keeps working with the prior release of this module.

## Verification

Part of the coordinated globals-convention change; proven end-to-end on infusal.io (array-format gsap + map-format modules coexist under the backward-compatible reader).

🤖 Generated with [Claude Code](https://claude.com/claude-code)