### PR TITLE
fix: avoid content-cache deadlock in eager index publishing

### DIFF
--- a/layouts/_partials/assets/search-index.html
+++ b/layouts/_partials/assets/search-index.html
@@ -20,10 +20,19 @@
     how `css.PostCSS` is deferred so PurgeCSS reads a complete hugo_stats.json).
     The deferred index would then never publish and its raw placeholder token
     would leak into the rendered page. So on Hugo < 0.164 publish the index
-    EAGERLY instead: correct, at the cost of the serial-render stall that
-    templates.Defer was introduced to avoid. Guard the eager path to run once
-    per language via site.Store. Hugo >= 0.164 keeps the deferred path.
+    EAGERLY instead, guarded to run once per language via site.Store. Hugo
+    >= 0.164 keeps the deferred path.
     (hugo.Version.Compare returns > 0 when the running version is older.)
+
+    The eager path MUST pass "raw" true: it runs inside a page render, and
+    reading .Plain / .Summary of other pages from there deadlocks against
+    the theme's render-once design — every page render primes its own
+    .Content, so the render workers hold their pages' content-cache entries
+    while the eager index build waits for them, and vice versa. The build
+    then hangs indefinitely (typically at the start of the second language
+    of a multilingual site). Raw mode indexes .RawContent with shortcode
+    tags stripped and never touches the content cache; see
+    utilities/GetSearchDocs.html for details.
 */ -}}
 {{- if le (hugo.Version.Compare "0.164.0") 0 -}}
     {{- with (templates.Defer (dict
@@ -39,7 +48,7 @@
     {{- $guard := printf "flexsearch-index-eager-%s" site.Language.Lang -}}
     {{- if not (site.Store.Get $guard) -}}
         {{- site.Store.Set $guard true -}}
-        {{- $docs := partial "utilities/GetSearchDocs.html" (dict "site" site) -}}
+        {{- $docs := partial "utilities/GetSearchDocs.html" (dict "site" site "raw" true) -}}
         {{- $index := resources.FromString (partial "utilities/GetSearchIndexPath.html" site) ($docs | jsonify) -}}
         {{- $noop := $index.RelPermalink -}}
     {{- end -}}

--- a/layouts/_partials/utilities/GetSearchDocs.html
+++ b/layouts/_partials/utilities/GetSearchDocs.html
@@ -16,6 +16,18 @@
     language that registered the deferred block. A bare (non-dict) context
     falls back to the `site` global for backward compatibility.
 
+    The optional key "raw" (default false) switches the text source from the
+    rendered content (.Plain / .Summary) to the unrendered .RawContent with
+    shortcode tags stripped. The eager publisher on Hugo < 0.164 MUST set it:
+    it runs inside a page render, and reading .Plain / .Summary of other pages
+    from there deadlocks against Hinode's render-once design — every page
+    render primes its own .Content, so the render workers hold their pages'
+    content-cache entries while the eager index build waits for them, and
+    vice versa. The build then hangs indefinitely at the start of the second
+    language of a multilingual site. Raw mode never touches the content
+    cache, at the cost of indexing unexpanded shortcode output. The deferred
+    path (Hugo >= 0.164) keeps the fully rendered text.
+
     Placeholder hygiene: a page that demos a search UI in its own content (e.g.
     a navbar shortcode with search enabled) embeds the deferred search-index
     publisher inside its .Content, which leaves a raw templates.Defer
@@ -25,8 +37,10 @@
     token (and one trailing whitespace) so the published index stays clean.
 */ -}}
 {{- $deferToken := `__hdeferred/\S+?__d=\s?` -}}
+{{- $shortcodeToken := `{{[<%](?s:.)*?[>%]}}` -}}
 {{- $site := site -}}
-{{- if reflect.IsMap . }}{{ with .site }}{{ $site = . }}{{ end }}{{ end -}}
+{{- $raw := false -}}
+{{- if reflect.IsMap . }}{{ with .site }}{{ $site = . }}{{ end }}{{ $raw = .raw | default false }}{{ end -}}
 {{- $sections := where (where $site.Pages "Kind" "section") "Title" "!=" "" -}}
 {{- $list := where $site.RegularPages "Title" "!=" "" | append $sections -}}
 {{- $list = where $list ".Params.searchExclude" "!=" true -}}
@@ -37,8 +51,11 @@
     {{- $title := or .Params.indexTitle .LinkTitle .Title -}}
     {{- if gt (strings.RuneCount $title) 33 }}{{ $title = print (substr $title 0 30) "..." }}{{ end -}}
     {{- if and $site.Params.main.titleCase (not $element.Params.exact) }}{{ $title = title $title }}{{ end -}}
+    {{- /* raw text stands in for .Plain/.Summary in raw mode, see header */ -}}
+    {{- $rawText := "" -}}
+    {{- if $raw }}{{ $rawText = replaceRE $shortcodeToken " " $element.RawContent | plainify }}{{ end -}}
     {{- $description := "" -}}
-    {{- with .Description }}{{ $description = . }}{{ else }}{{ $description = $element.Summary }}{{ end -}}
+    {{- with .Description }}{{ $description = . }}{{ else }}{{ $description = cond $raw $rawText $element.Summary }}{{ end -}}
     {{/*
         Both htmlUnescape calls below are load-bearing; neither may be dropped:
         - the first (before the whitespace collapse) decodes source entities, so e.g.
@@ -61,7 +78,11 @@
     {{- $description = replaceRE $deferToken "" $description -}}
     {{- $description = trim (replaceRE `[\s\p{Zs}\p{Zl}\p{Zp}\x{000B}\x{0085}\x{FEFF}]+` " " $description) " " | truncate 100 "..." | htmlUnescape -}}
     {{- $content := "" -}}
-    {{- if $site.Params.modules.flexsearch.summaryOnly -}}
+    {{- if $raw -}}
+        {{- $content = replaceRE "[{}]" "" $rawText -}}
+        {{- /* summaryOnly keeps the index small; approximate a summary from the raw text */ -}}
+        {{- if $site.Params.modules.flexsearch.summaryOnly }}{{ $content = substr $content 0 500 }}{{ end -}}
+    {{- else if $site.Params.modules.flexsearch.summaryOnly -}}
         {{- $content = replaceRE "[{}]" "" (.Summary | plainify) -}}
     {{- else -}}
         {{- $content = replaceRE "[{}]" "" .Plain -}}


### PR DESCRIPTION
## Problem

On Hugo < 0.164 the search index is published **eagerly** inside the first page render of each language (the `templates.Defer` path is unreliable there when `resources.PostProcess` is in play). `GetSearchDocs.html` then reads `.Plain` / `.Summary` of every page **while the render workers hold their own pages' content-cache entries** — under Hinode's render-once design every page render primes its own `.Content`. Both sides wait on each other's `contentRendered` cache entries and the build hangs forever at 0% CPU, typically right at the start of the second language of a multilingual site. Hugo's `timeout` setting does not cover these waits, so there is no error — just a silent hang.

Found while upgrading a bilingual production site to the v3 module generation (CloudCannon-hosted, so Hugo is pinned below 0.164): every full build deadlocked after the first language's phase. Goroutine dumps show all render workers parked in `lazycache.GetOrCreate` → `cachedContentScope.contentRendered` waits, with the page feeder blocked on the render channel. Either language builds fine on its own; the dual-language build never completes.

## Fix

- Add an opt-in `raw` mode to `utilities/GetSearchDocs.html` that sources the index text from `.RawContent` with shortcode tags stripped — no content-cache interaction, so the deadlock cannot occur.
- The eager path in `assets/search-index.html` now passes `"raw" true`. The deferred path (Hugo ≥ 0.164) is unchanged and keeps indexing the fully rendered text.
- `summaryOnly` in raw mode approximates a summary by truncating the raw text.

Trade-off (documented in both partials): on Hugo < 0.164 the indexed text is the unrendered Markdown, so shortcode *output* is not searchable. That beats a build that never completes.

## Verification

- `npm test` passes on the deferred path (default).
- Forced the eager path (gate flipped to `if false` locally): `npm test` passes, index contains all 10 exampleSite documents, no shortcode noise, descriptions within budget.
- The equivalent change applied as a site shadow takes the affected bilingual production build from an indefinite hang to ~40 s, with a clean ~600-document index across both languages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)