### PR TITLE
fix: avoid eager cond evaluation of Summary in raw-mode description fallback

### DIFF
--- a/layouts/_partials/utilities/GetSearchDocs.html
+++ b/layouts/_partials/utilities/GetSearchDocs.html
@@ -55,7 +55,9 @@
     {{- $rawText := "" -}}
     {{- if $raw }}{{ $rawText = replaceRE $shortcodeToken " " $element.RawContent | plainify }}{{ end -}}
     {{- $description := "" -}}
-    {{- with .Description }}{{ $description = . }}{{ else }}{{ $description = cond $raw $rawText $element.Summary }}{{ end -}}
+    {{- /* no `cond` here: cond evaluates BOTH branches, so it would force .Summary (a
+         content-cache read) even in raw mode and reintroduce the eager-path deadlock */ -}}
+    {{- if .Description }}{{ $description = .Description }}{{ else if $raw }}{{ $description = $rawText }}{{ else }}{{ $description = $element.Summary }}{{ end -}}
     {{/*
         Both htmlUnescape calls below are load-bearing; neither may be dropped:
         - the first (before the whitespace collapse) decodes source entities, so e.g.


### PR DESCRIPTION
## Problem

Follow-up to #319. The raw-mode description fallback shipped in v5.3.1 reads:

```
{{ $description = cond $raw $rawText $element.Summary }}
```

Hugo's `cond` (like all template functions) **evaluates both branches eagerly**, so `.Summary` — a content-cache read — still executes for every page without a `description`, even in raw mode. That reintroduces exactly the eager-path render deadlock raw mode was added to prevent: on the affected bilingual production site, v5.3.1 hangs the build within seconds of page rendering starting (all render workers parked in `contentRendered` cache waits), because many pages there rely on the summary fallback.

The exampleSite test didn't catch it: a small single-language site has no render contention, so the `.Summary` reads simply succeed.

## Fix

Replace the `cond` with an explicit `if / else if / else` chain (a `with … else if` form is not valid template syntax, hence plain `if .Description`), and add a comment warning future editors why `cond` must not be used here. Raw mode now provably never touches the content cache.

## Verification

- `npm test` passes on the deferred path.
- `npm test` passes with the eager path forced (version gate flipped locally).
- Applied to the vendored module on the affected production site: the full bilingual build completes in ~40 s with a clean 596-document index across both languages, navbar and warnings unchanged. Without this patch the same build deadlocks before the first page finishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)